### PR TITLE
Add composer json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "issues": "https://github.com/sebastianbergmann/finder-facade/issues"
     },
     "require": {
-        "theseer/f-dom-document": ">=1.3.1"
+        "theseer/fdomdocument": ">=1.3.1"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Add a composer.json file to enable loading this library via composer.
This is necessary to make phploc/phploc work with composer installation
(see https://github.com/sebastianbergmann/phploc/issues/35)

NB: Please do not merge this until https://github.com/theseer/fDOMDocument/pull/16 has been merged and a package created on packagist.  The composer.json file in this repo lists that repo as a requirement.
