### PR TITLE
Allow versions >2.1 of symfony/finder in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "theseer/fdomdocument": ">=1.3.1",
-        "symfony/finder": ">=2.1.0,<2.2.0"
+        "symfony/finder": ">=2.1.0,<2.3.0"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
This makes it possible for composer to install this package within a
symfony2.2 application
