### PR TITLE
Support Symfony3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "theseer/fdomdocument": "~1.3",
-        "symfony/finder": "~2.3"
+        "symfony/finder": "~2|~3"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
"symfony/finder": "~2.3" -> "symfony/finder": "~2|~3"